### PR TITLE
eTAOC fixes

### DIFF
--- a/source/initial.F90
+++ b/source/initial.F90
@@ -1257,13 +1257,22 @@ end subroutine read_ts_namelist
       enddo
       !$OMP END PARALLEL DO
 
-   case ('amuse')
+   case ('amuse_restart')
       first_step = .false.
       if (my_task == master_task) then
          write(stdout,'(a63)') &
-        'Initial T,S provided from Omuse accessor'
+        'Initial T,S provided from Omuse accessor, providing both old & new state'
          call POP_IOUnitsFlush(POP_stdout) ; call POP_IOUnitsFlush(stdout)
       endif
+
+   case ('amuse')
+      first_step = .true.
+      if (my_task == master_task) then
+         write(stdout,'(a63)') &
+        'Initial T,S provided from Omuse accessor, providing only a single state'
+         call POP_IOUnitsFlush(POP_stdout) ; call POP_IOUnitsFlush(stdout)
+      endif
+
 
 !-----------------------------------------------------------------------
 !

--- a/source/initial.F90
+++ b/source/initial.F90
@@ -1257,6 +1257,14 @@ end subroutine read_ts_namelist
       enddo
       !$OMP END PARALLEL DO
 
+   case ('amuse')
+      first_step = .false.
+      if (my_task == master_task) then
+         write(stdout,'(a63)') &
+        'Initial T,S provided from Omuse accessor'
+         call POP_IOUnitsFlush(POP_stdout) ; call POP_IOUnitsFlush(stdout)
+      endif
+
 !-----------------------------------------------------------------------
 !
 !  bad initialization option

--- a/source/restart.F90
+++ b/source/restart.F90
@@ -75,6 +75,9 @@
    character (POP_charLength), public :: &
       restart_outfile       ! restart output filename root
 
+   character (POP_charLength), public :: &
+      last_restart_outfile  ! last restart output filename
+
    integer (POP_i4), public :: &
       restart_freq          ! restart frequency
 
@@ -1177,6 +1180,8 @@
                                                   &/'.'/&
                                                   &/trim(file_suffix)
 
+   last_restart_outfile = write_restart_filename
+
 !-----------------------------------------------------------------------
 !
 !  create output file
@@ -1648,6 +1653,7 @@
 !maltrud define defaults
    restart_start_opt = 'nstep'
    restart_start = 1
+   last_restart_outfile = ''
 
    if (my_task == master_task) then
       open (nml_in, file=nml_filename, status='old',iostat=nml_error)


### PR DESCRIPTION
 - add options to indicate amuse/omuse restart data:
     - "amuse_restart", where both old and new state data are specified through amuse copy into POP arrays. Initial Euler step is bypassed.
     - "amuse", where a single state data is provided and an Euler step is required upon starting the simulation (coming from i-emic data for instance).
 - store the last restart file written to disk.